### PR TITLE
Fixed Error 3 that  was caused by multiple API calls on navigation

### DIFF
--- a/RickAndMortyApp/Features/Presentation/Views/Home/View/HomeView.swift
+++ b/RickAndMortyApp/Features/Presentation/Views/Home/View/HomeView.swift
@@ -41,7 +41,7 @@ struct HomeView: View {
         .statusBar(hidden: !showStatusBar)
         .onAppear {
             Task {
-                await viewModel.loadCharacterList()
+                await viewModel.ensureInitialLoad()
             }
         }
         .alert(isPresented: $viewModel.hasError) {


### PR DESCRIPTION
- Add hasInitialLoadCompleted flag to prevent redundant data loading
- Add isApiCallInProgress flag to prevent concurrent API calls
- Replace direct loadCharacterList() call in onAppear with ensureInitialLoad()
- Add ensureInitialLoad() method that only loads data when necessary
- Update refreshCharacterList() to reset hasInitialLoadCompleted flag
- Logging for debugging